### PR TITLE
Fix adding same item to cart quantity

### DIFF
--- a/pages/product/_id.vue
+++ b/pages/product/_id.vue
@@ -78,7 +78,7 @@ export default {
       let item = this.product;
       item.quantity = this.quantity;
       this.tempcart.push(item);
-      this.$store.commit("addToCart", item);
+      this.$store.commit("addToCart", {...item});
     }
   }
 };


### PR DESCRIPTION
When adding the same item to cart, it seems it only adds a reference of `this.product` in `pages/product/_id.vue`. Cloning the item before adding it to the state fixes the issue.

Closes #2.