### PR TITLE
Fix invalid featured product on products page

### DIFF
--- a/components/AppFeaturedProducts.vue
+++ b/components/AppFeaturedProducts.vue
@@ -8,7 +8,7 @@
         <img :src="`/products/${product.img}`" />
         <h3>{{ product.name }}</h3>
         <h4>{{ product.price | dollar }}</h4>
-        <NuxtLink :to="`product/${product.id}`">
+        <NuxtLink :to="`/product/${product.id}`">
           <button class="multi-item">View Item ></button>
         </NuxtLink>
       </div>


### PR DESCRIPTION
Clicking a featured product while viewing another product sends users to a non-existent page, either `.../product/product/ID` or `.../product/ID/product/ID`. Passing an absolute path to `NuxtLink` solves this. Closes #1