### PR TITLE
Fix typo: 'npm dev' -> 'npm run dev'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are two articles explaining how this site is set up:
 $ yarn install or npm install
 
 # serve with hot reload at localhost:3000
-$ yarn dev or npm dev
+$ yarn dev or npm run dev
 
 # build for production and launch server
 $ yarn build or npm build


### PR DESCRIPTION
The command `npm dev` does not exist