### PR TITLE
fix(input-quantity): use `pattern` attribute

### DIFF
--- a/pages/product/_id.vue
+++ b/pages/product/_id.vue
@@ -18,7 +18,7 @@
         <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iusto velit dolores repudiandae animi quidem, eveniet quod dolor facilis dicta eligendi ullam error. Assumenda in fugiat natus enim similique nam itaque.</p>
         <p class="quantity">
           <button class="update-num" @click="quantity > 0 ? quantity-- : quantity = 0">-</button>
-          <input type="number" v-model="quantity" />
+          <input type="text" pattern="\d+" v-model="quantity" required />
           <button class="update-num" @click="quantity++">+</button>
         </p>
         <p>


### PR DESCRIPTION
The input have a control (behavior of using a `type="number`) that may block the value of input, since it has a custom control for increasing and decreasing the quantity, the default control must be removed.

To do that, I change the `type` attribute from `number` to `text` and add `pattern="\d+"` for validation then I add `required` attribute.

Fix #31 